### PR TITLE
Install Colima with Docker runtime

### DIFF
--- a/tasks/docker.yaml
+++ b/tasks/docker.yaml
@@ -1,6 +1,6 @@
-- name: Install Docker
+- name: Install Colima with Docker runtime
   community.general.homebrew:
-    name: docker
+    name: [colima, docker]
     state: present
   tags:
     - docker


### PR DESCRIPTION
Docker cannot be easily installed on Mac since `docker` formulae does not include docker daemon.  
Docker on Mac is good, but requires manual setup.
Colima solves the problem with minimal setup.